### PR TITLE
Update CMake doc for automatic test registration

### DIFF
--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -88,6 +88,18 @@ include(Catch)
 catch_discover_tests(foo)
 ```
 
+When using `FetchContent`, `include(Catch)` will fail unless 
+`CMAKE_MODULE_PATH` is explicitly updated to include the contrib
+directory.
+
+```cmake
+# ... FetchContent ...
+#
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(CTest)
+include(Catch)
+catch_discover_tests()
+```
 
 #### Customization
 `catch_discover_tests` can be given several extra argumets:


### PR DESCRIPTION
`FetchContent` doesn't include `contrib` directory as part of `CMAKE_MODULE_PATH`. This results into `include(Catch)` to fail. This patch just updates the documentation describing how to do include the path, so the new users don't have to figure this out themselves.

Source: https://github.com/catchorg/Catch2/issues/2103#issuecomment-730626324

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
